### PR TITLE
Allow reusing available cards without removing them

### DIFF
--- a/index.html
+++ b/index.html
@@ -234,10 +234,13 @@
 
         // Move card to done
         function markCardAsDone(cardId) {
-            const cardIndex = availableCards.findIndex(c => c.id === cardId);
-            if (cardIndex !== -1) {
-                const card = availableCards.splice(cardIndex, 1)[0];
-                doneCards.push(card);
+            const card = availableCards.find(c => c.id === cardId);
+            if (card) {
+                doneCards.push({
+                    id: generateId(),
+                    name: card.name,
+                    sourceId: card.id
+                });
                 saveToStorage();
                 renderCards();
             }
@@ -247,8 +250,7 @@
         function markCardAsAvailable(cardId) {
             const cardIndex = doneCards.findIndex(c => c.id === cardId);
             if (cardIndex !== -1) {
-                const card = doneCards.splice(cardIndex, 1)[0];
-                availableCards.push(card);
+                doneCards.splice(cardIndex, 1);
                 saveToStorage();
                 renderCards();
             }


### PR DESCRIPTION
## Summary
- keep cards in the available section when marking them as done
- allow adding the same card to the done list multiple times and remove individual entries only

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e41a8f39a4833193afe7f3aec86980